### PR TITLE
Adds a name key to repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "repositories": [
-        {
+        "drupal": {
             "type": "composer",
             "url": "https://packagist.drupal-composer.org"
         }


### PR DESCRIPTION
If we have a name key for drupal-project in composer.json, it'll be easier to change the repository from drupal-packagist to packages.drupal.org:

```composer config repositories.drupal composer https://packages.drupal.org/8```